### PR TITLE
Add back the async texture transfer optimization

### DIFF
--- a/src/livesplit_renderer.rs
+++ b/src/livesplit_renderer.rs
@@ -696,37 +696,29 @@ impl eframe::App for LiveSplitCoreRenderer {
             ctx.send_viewport_cmd(egui::viewport::ViewportCommand::CancelClose)
         }
         let viewport = ctx.input(|i| i.screen_rect);
-        self.glow_canvas.update_frame_buffer(|frame_buffer| {
-            {
-                let timer = self.timer.read().unwrap();
-                let snapshot = timer.snapshot();
-                match &mut self.layout_state {
-                    None => {
-                        self.layout_state = Some(self.layout.state(&snapshot));
-                    }
-                    Some(layout_state) => {
-                        self.layout.update_state(layout_state, &snapshot);
-                    }
-                };
-            }
-            let sz = viewport.size();
-
-            if let Some(layout_state) = &self.layout_state {
-                let szu32 = [sz.x as u32, sz.y as u32];
-                let sz = [sz.x as usize, sz.y as usize];
+        self.glow_canvas.update_frame_buffer(
+            viewport,
+            frame.gl().unwrap(),
+            |frame_buffer, sz, stride| {
                 {
-                    let mut buffer = frame_buffer.write().unwrap();
-                    buffer.resize(sz[0] * sz[1] * 4, 0);
-                    self.renderer.render(
-                        layout_state,
-                        buffer.as_mut_slice(),
-                        szu32,
-                        sz[0] as u32,
-                        false,
-                    );
+                    let timer = self.timer.read().unwrap();
+                    let snapshot = timer.snapshot();
+                    match &mut self.layout_state {
+                        None => {
+                            self.layout_state = Some(self.layout.state(&snapshot));
+                        }
+                        Some(layout_state) => {
+                            self.layout.update_state(layout_state, &snapshot);
+                        }
+                    };
                 }
-            }
-        });
+
+                if let Some(layout_state) = &self.layout_state {
+                    self.renderer
+                        .render(layout_state, frame_buffer, sz, stride, true);
+                }
+            },
+        );
         self.glow_canvas
             .paint_layer(ctx, egui::LayerId::background(), viewport);
         //self.glow_canvas.paint_immediate(frame.gl().unwrap(), viewport);


### PR DESCRIPTION
Issue with the previous attempt appears to be the way I was trying to use `tex_image_2d` during the init. I wasn't binding my texture so I was stomping on the egui texture properties and they were incompatible.